### PR TITLE
Add typing information

### DIFF
--- a/changelogs/fragments/22-typing.yml
+++ b/changelogs/fragments/22-typing.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Add typing information for the ``inventory_filter`` plugin utils (https://github.com/ansible-collections/community.library_inventory_filtering/pull/22)."

--- a/plugins/plugin_utils/inventory_filter.pyi
+++ b/plugins/plugin_utils/inventory_filter.pyi
@@ -1,0 +1,22 @@
+import typing as t
+from collections.abc import Mapping
+
+from ansible.plugins.inventory import BaseInventoryPlugin
+
+class _IncludeFilter(t.TypedDict):
+    include: str | bool
+
+class _ExcludeFilter(t.TypedDict):
+    exclude: str | bool
+
+Filters = list[_IncludeFilter | _ExcludeFilter]
+
+def parse_filters(
+    filters: list[t.Any] | None,
+) -> Filters: ...
+def filter_host(
+    inventory_plugin: BaseInventoryPlugin,
+    host: str,
+    host_vars: Mapping[str, t.Any],
+    filters: Filters,
+) -> bool: ...

--- a/plugins/plugin_utils/inventory_filter.pyi
+++ b/plugins/plugin_utils/inventory_filter.pyi
@@ -1,3 +1,7 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 import typing as t
 from collections.abc import Mapping
 

--- a/tests/sanity/extra/no-unwanted-files.py
+++ b/tests/sanity/extra/no-unwanted-files.py
@@ -19,6 +19,7 @@ def main():
         '.ps1',
         '.psm1',
         '.py',
+        '.pyi',
     )
 
     skip_paths = set([
@@ -32,6 +33,9 @@ def main():
             continue
 
         if any(path.startswith(skip_directory) for skip_directory in skip_directories):
+            continue
+
+        if os.path.split(path)[1] in {'py.typed'}:
             continue
 
         ext = os.path.splitext(path)[1]

--- a/tests/sanity/extra/no-unwanted-files.py
+++ b/tests/sanity/extra/no-unwanted-files.py
@@ -35,7 +35,7 @@ def main():
         if any(path.startswith(skip_directory) for skip_directory in skip_directories):
             continue
 
-        if os.path.split(path)[1] in {'py.typed'}:
+        if os.path.split(path)[1] in ('py.typed',):
             continue
 
         ext = os.path.splitext(path)[1]


### PR DESCRIPTION
##### SUMMARY
While we can't really add the typing information inline, since we still support Ansible 2.9 (and thus also Python 2.6), we can add a stub file. Since we have only one module, this is pretty simple.

I've tested this with community.dns (with my current development version).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
inventory_filter plugin utils
