### PR TITLE
ansible-core 2.20: avoid deprecated functionality

### DIFF
--- a/changelogs/fragments/38-deprecations.yml
+++ b/changelogs/fragments/38-deprecations.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Avoid deprecated functionality in ansible-core 2.20 (https://github.com/ansible-collections/community.library_inventory_filtering/pull/38)."

--- a/plugins/plugin_utils/inventory_filter.py
+++ b/plugins/plugin_utils/inventory_filter.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.errors import AnsibleError, AnsibleParserError
-from ansible.module_utils.common._collections_compat import Mapping
+from ansible.module_utils.six.moves.collections_abc import Mapping
 from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.six import string_types

--- a/plugins/plugin_utils/inventory_filter.py
+++ b/plugins/plugin_utils/inventory_filter.py
@@ -10,10 +10,16 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.errors import AnsibleError, AnsibleParserError
-from ansible.module_utils.six.moves.collections_abc import Mapping
 from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.six import string_types
+
+
+try:
+    from collections.abc import Mapping
+except ImportError:
+    # Python 2.x
+    from collections import Mapping  # pylint: disable=deprecated-class
 
 
 _ALLOWED_KEYS = ("include", "exclude")

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,2 +1,4 @@
 noxfile.py future-import-boilerplate
 noxfile.py metaclass-boilerplate
+plugins/plugin_utils/inventory_filter.py pylint:bad-option-value
+plugins/plugin_utils/inventory_filter.py pylint:ansible-bad-import-from

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,2 +1,4 @@
 noxfile.py future-import-boilerplate
 noxfile.py metaclass-boilerplate
+plugins/plugin_utils/inventory_filter.py pylint:bad-option-value
+plugins/plugin_utils/inventory_filter.py pylint:ansible-bad-import-from

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,0 +1,1 @@
+plugins/plugin_utils/inventory_filter.py pylint:ansible-bad-import-from

--- a/tests/sanity/ignore-2.12.txt.license
+++ b/tests/sanity/ignore-2.12.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,0 +1,1 @@
+plugins/plugin_utils/inventory_filter.py pylint:ansible-bad-import-from

--- a/tests/sanity/ignore-2.13.txt.license
+++ b/tests/sanity/ignore-2.13.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,0 +1,1 @@
+plugins/plugin_utils/inventory_filter.py pylint:ansible-bad-import-from

--- a/tests/sanity/ignore-2.14.txt.license
+++ b/tests/sanity/ignore-2.14.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,0 +1,1 @@
+plugins/plugin_utils/inventory_filter.py pylint:ansible-bad-import-from

--- a/tests/sanity/ignore-2.15.txt.license
+++ b/tests/sanity/ignore-2.15.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,0 +1,1 @@
+plugins/plugin_utils/inventory_filter.py pylint:ansible-bad-import-from

--- a/tests/sanity/ignore-2.16.txt.license
+++ b/tests/sanity/ignore-2.16.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,0 +1,1 @@
+plugins/plugin_utils/inventory_filter.py pylint:ansible-bad-import-from

--- a/tests/sanity/ignore-2.17.txt.license
+++ b/tests/sanity/ignore-2.17.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,0 +1,1 @@
+plugins/plugin_utils/inventory_filter.py pylint:ansible-bad-import-from

--- a/tests/sanity/ignore-2.18.txt.license
+++ b/tests/sanity/ignore-2.18.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -1,0 +1,1 @@
+plugins/plugin_utils/inventory_filter.py pylint:ansible-bad-import-from

--- a/tests/sanity/ignore-2.19.txt.license
+++ b/tests/sanity/ignore-2.19.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,0 +1,1 @@
+plugins/plugin_utils/inventory_filter.py pylint:ansible-bad-import-from

--- a/tests/sanity/ignore-2.20.txt.license
+++ b/tests/sanity/ignore-2.20.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,2 +1,4 @@
 noxfile.py future-import-boilerplate
 noxfile.py metaclass-boilerplate
+plugins/plugin_utils/inventory_filter.py pylint:bad-option-value
+plugins/plugin_utils/inventory_filter.py pylint:ansible-bad-import-from


### PR DESCRIPTION
##### SUMMARY
ansible.module_utils._text and ansible.module_utils.common._collections_compat have been deprecated.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
various
