### PR TITLE
Avoid six in favor of ugly ifs

### DIFF
--- a/changelogs/fragments/39-six.yml
+++ b/changelogs/fragments/39-six.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "Stop using ``ansible.module_utils.six`` to avoid user-facing deprecation messages with ansible-core 2.20, while still supporting older ansible-core versions
+     (https://github.com/ansible-collections/community.library_inventory_filtering/pull/39)."

--- a/plugins/plugin_utils/inventory_filter.py
+++ b/plugins/plugin_utils/inventory_filter.py
@@ -9,11 +9,17 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import sys
+
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.parsing.convert_bool import boolean
-from ansible.module_utils.six import string_types
 
+
+if sys.version_info[0] == 2:
+    string_types = (str, unicode)  # noqa: F821, pylint: disable=undefined-variable
+else:
+    string_types = (bytes, str)
 
 try:
     from collections.abc import Mapping


### PR DESCRIPTION
##### SUMMARY
Now that ansible.module_utils.six prints user-facing deprecation messages, we really have to avoid using it. This totally sucks :-(

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugin utils
